### PR TITLE
JPMS support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jmh.version>1.19</jmh.version>
     <coveralls.token>NMdOvhUZp5nBfOkLNcaLYau8G3jGUaSCY</coveralls.token>
-    <javac.target>1.7</javac.target>
   </properties>
 
   <profiles>
@@ -62,16 +61,44 @@
   </profiles>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.8.0</version>
+          <executions>
+            <execution>
+              <!-- compile everything for Java 9: -->
+              <id>default-compile</id>
+              <configuration>
+                <release>9</release>
+              </configuration>
+            </execution>
+            <!--
+                compile everything again with default configuration,
+                which is Java 7 excluding module-info:
+            -->
+            <execution>
+              <id>base-compile</id>
+              <goals>
+                <goal>compile</goal>
+              </goals>
+              <configuration>
+                <release>7</release>
+                <excludes>
+                  <exclude>module-info.java</exclude>
+                </excludes>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.7.0</version>
-        <configuration>
-          <compilerVersion>${javac.target}</compilerVersion>
-          <source>${javac.target}</source>
-          <target>${javac.target}</target>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -50,51 +50,70 @@
 
   <profiles>
     <profile>
-      <id>java8</id>
+      <id>java-old</id>
       <activation>
-        <jdk>1.8</jdk>
+        <jdk>[1.7,1.9)</jdk>
       </activation>
-      <properties>
-        <javac.target>1.6</javac.target>
-      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.8.0</version>
+            <configuration>
+              <source>1.7</source>
+              <target>1.7</target>
+              <excludes>
+                <exclude>module-info.java</exclude>
+              </excludes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>java-current</id>
+      <activation>
+        <jdk>[9,18)</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.8.0</version>
+            <executions>
+              <execution>
+                <!-- compile everything for Java 9: -->
+                <id>default-compile</id>
+                <configuration>
+                  <release>9</release>
+                </configuration>
+              </execution>
+              <!--
+                  compile everything again with default configuration,
+                  which is Java 7 excluding module-info:
+              -->
+              <execution>
+                <id>base-compile</id>
+                <goals>
+                  <goal>compile</goal>
+                </goals>
+                <configuration>
+                  <release>7</release>
+                  <excludes>
+                    <exclude>module-info.java</exclude>
+                  </excludes>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.0</version>
-          <executions>
-            <execution>
-              <!-- compile everything for Java 9: -->
-              <id>default-compile</id>
-              <configuration>
-                <release>9</release>
-              </configuration>
-            </execution>
-            <!--
-                compile everything again with default configuration,
-                which is Java 7 excluding module-info:
-            -->
-            <execution>
-              <id>base-compile</id>
-              <goals>
-                <goal>compile</goal>
-              </goals>
-              <configuration>
-                <release>7</release>
-                <excludes>
-                  <exclude>module-info.java</exclude>
-                </excludes>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
-      </plugins>
-    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/rut-benchmark/pom.xml
+++ b/rut-benchmark/pom.xml
@@ -62,6 +62,18 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.1.1</version>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>io.norberg.rut.benchmark</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/rut/pom.xml
+++ b/rut/pom.xml
@@ -49,7 +49,7 @@
       <plugin>
         <groupId>com.github.siom79.japicmp</groupId>
         <artifactId>japicmp-maven-plugin</artifactId>
-        <version>0.6.1</version>
+        <version>0.13.0</version>
         <configuration>
           <oldVersion>
             <dependency>

--- a/rut/src/main/java/module-info.java
+++ b/rut/src/main/java/module-info.java
@@ -1,0 +1,3 @@
+module io.norberg.rut {
+  exports io.norberg.rut;
+}


### PR DESCRIPTION
Trying to make `rut` into actual JPMS module, while keeping Java 7 compatibility.

`rut` itself has a module info now, but `rut-benchmark` has only `Automatic-Module-Name` because JMH does not have a module name yet.

Now I will need help to figure out Travis CI configuration for this...