### PR TITLE
Add string accepting methods

### DIFF
--- a/rut/src/main/java/io/norberg/rut/Router.java
+++ b/rut/src/main/java/io/norberg/rut/Router.java
@@ -1,9 +1,6 @@
 package io.norberg.rut;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 import static io.norberg.rut.Encoding.decode;
 import static io.norberg.rut.Router.Status.METHOD_NOT_ALLOWED;
@@ -306,6 +303,81 @@ public final class Router<T> {
      */
     public int paramValueEnd(final int i) {
       return captor.valueEnd(i);
+    }
+
+    /**
+     * Returns the index for a given parameter name, if it exists.
+     * @param paramName The name of the param
+     * @return An {@link OptionalInt} representing the index.
+     */
+    private OptionalInt paramIndex(String paramName) {
+      for (int i = 0; i < params(); i++) {
+        if (paramName(i).equals(paramName)) {
+          return OptionalInt.of(i);
+        }
+      }
+      return OptionalInt.empty();
+    }
+
+    /**
+     * Returns the index for a given parameter name, if it exists.
+     * @param paramName The name of the param
+     * @return An {@link OptionalInt} representing the index.
+     * @throws RuntimeException if there is no parameter for that name.
+     */
+    private int paramIndexOrThrow(String paramName) {
+      return paramIndex(paramName)
+              .orElseThrow(() -> new RuntimeException("No parameter: " + paramName));
+    }
+
+    /**
+     * Get the value of the captured path parameter.
+     *
+     * @param paramName The name of the parameter.
+     */
+    public CharSequence paramValue(final String paramName) {
+      return paramValue(paramIndexOrThrow(paramName));
+    }
+
+    /**
+     * Get the URL decoded value of the captured path parameter.
+     *
+     * @param paramName The name of the parameter.
+     * @return The decoded value or null if the encoding is invalid.
+     */
+    public CharSequence paramValueDecoded(final String paramName) {
+      return paramValueDecoded(paramIndexOrThrow(paramName));
+    }
+
+    /**
+     * Get the parameter type of the captured path parameter .
+     *
+     * @param paramName The name of the parameter.
+     */
+    public ParameterType paramType(final String paramName) {
+      return paramType(paramIndexOrThrow(paramName));
+    }
+
+    /**
+     * Get start offset into the routed path of the captured parameter.
+     *
+     * @param paramName The name of the parameter.
+     * @see #paramValue
+     * @see #paramValueEnd
+     */
+    public int paramValueStart(final String paramName) {
+      return paramValueStart(paramIndexOrThrow(paramName));
+    }
+
+    /**
+     * Get end offset into the routed path of the captured parameter.
+     *
+     * @param paramName The name of the parameter.
+     * @see #paramValue
+     * @see #paramValueStart
+     */
+    public int paramValueEnd(final String paramName) {
+      return paramValueEnd(paramIndexOrThrow(paramName));
     }
 
     /**

--- a/rut/src/main/java/io/norberg/rut/Router.java
+++ b/rut/src/main/java/io/norberg/rut/Router.java
@@ -1,6 +1,10 @@
 package io.norberg.rut;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.OptionalInt;
 
 import static io.norberg.rut.Encoding.decode;
 import static io.norberg.rut.Router.Status.METHOD_NOT_ALLOWED;

--- a/rut/src/test/java/io/norberg/rut/RouterTest.java
+++ b/rut/src/test/java/io/norberg/rut/RouterTest.java
@@ -19,8 +19,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RouterTest {
@@ -442,5 +441,26 @@ public class RouterTest {
       b.append(s);
     }
     return b.toString();
+  }
+
+  @Test
+  public void testParamByName() {
+    Router<String> router = Router.builder(String.class)
+            .route("GET", "/<param>/<end:path>", "")
+            .build();
+    Router.Result<String> result = router.result();
+    assertThat(router.route("GET", "/foobar/the/end", result), is(SUCCESS));
+    assertThat(result.paramType("param"), is(SEGMENT));
+    assertThat(result.paramType("end"), is(PATH));
+
+    router = Router.builder(String.class)
+            .route("GET", "/abc/<param>", "")
+            .build();
+    result = router.result();
+    assertThat(router.route("GET", "/abc/r%c3%A4k%20sm%C3%B6rg%C3%A5s", result), is(SUCCESS));
+    assertThat(result.paramValue("param").toString(), is("r%c3%A4k%20sm%C3%B6rg%C3%A5s"));
+    assertThat(result.paramValueDecoded("param").toString(), is("räk smörgås"));
+    assertThat(result.paramValueStart("param"), is(5));
+    assertThat(result.paramValueEnd("param"), is(33));
   }
 }

--- a/rut/src/test/java/io/norberg/rut/RouterTest.java
+++ b/rut/src/test/java/io/norberg/rut/RouterTest.java
@@ -19,7 +19,8 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RouterTest {


### PR DESCRIPTION
Potential things to bikeshed:

* Method names. You alluded to `paramValueByName` and `paramValueDecodedByName`. Personally I don't see that much of a point unless we can imagine another `paramValueByX` that accepts a `String` or you want to take a hardline stance and make this usage pattern less ergonomic so people use the faster index lookups. My point of reference here is `ResultSet`. It has both `rs.getString(1)` and `rs.getString("columnName")`

* Throwing over returning `Optional<String>`. Given a totally blank slate I might have suggested the `Optional`, but I *think* having consistent behavior with the existing index lookups is more desirable.

* Should `paramIndex` be exposed? Can always make that determination later.

* If `paramIndex` is exposed, should it return an `OptionalInt` or an `int` with a throw? When its not exposed its whatever.